### PR TITLE
Add CMake option to 'Generate include graph'

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -33,9 +33,9 @@ CPMFindPackage(
   GITHUB_REPOSITORY assimp/assimp
   GIT_TAG master
   OPTIONS
-    ASSIMP_WARNINGS_AS_ERRORS OFF
-    ASSIMP_BUILD_TESTS OFF
-    ASSIMP_NO_EXPORT ON
+    "ASSIMP_WARNINGS_AS_ERRORS OFF"
+    "ASSIMP_BUILD_TESTS OFF"
+    "ASSIMP_NO_EXPORT ON"
 )
 
 # download a single file from stb

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,4 +1,5 @@
 option(SANITIZE "Option referring to sanitizers (cppcheck, iwyu, additional warnings)" OFF)
 option(BINARY_DEPS "Option referring to dependency installation (OFF - compile from source, ON - download binaries)" ON)
 option(GENERATE_DEPENDENCY_GRAPH "Option referring to dependency graph generation in png format" OFF)
+option(GENERATE_INCLUDE_GRAPH "Option referring to include graph generation in png format" OFF)
 option(FORMAT_SOURCE "Option referring to formatting before compiling" OFF)

--- a/cmake/scripts.cmake
+++ b/cmake/scripts.cmake
@@ -49,5 +49,13 @@ if (cmake-scripts_ADDED)
     include(${cmake-scripts_SOURCE_DIR}/dependency-graph.cmake)
     gen_dep_graph(png)
   endif()
+  if (GENERATE_INCLUDE_GRAPH)
+    execute_process (
+      COMMAND bash -c "\
+        cinclude2dot --src=src --merge=module > include-graph.dot && \
+        dot -Tpng include-graph.dot > build/include-graph.png \
+        rm include-graph.dot"
+    )
+  endif()
 endif()
 


### PR DESCRIPTION
Uses 'cinclude2dot' and 'graphviz' utilities to generate a png file containing include graph